### PR TITLE
feat: add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,70 @@
+name: Release to PyPI
+
+on:
+    push:
+        tags:
+            - "v*"
+
+jobs:
+    build:
+        name: Build distribution
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v6
+            - name: Set up uv
+              uses: astral-sh/setup-uv@v7
+              with:
+                  activate-environment: "true"
+                  python-version: "3.13"
+
+            - name: Install build tools
+              run: pip install build
+
+            - name: Build sdist and wheel
+              run: python -m build
+
+            - name: Store the distribution packages
+              uses: actions/upload-artifact@v6
+              with:
+                  name: infer-check
+                  path: dist/
+
+    publish-to-testpypi:
+        name: Publish to TestPyPI
+        needs: build
+        runs-on: ubuntu-latest
+        environment:
+            name: testpypi
+            url: https://test.pypi.org
+        permissions:
+            id-token: write
+        steps:
+            - name: Download all the dists
+              uses: actions/download-artifact@v6
+              with:
+                  name: infer-check
+                  path: dist/
+
+            - name: Publish to TestPyPI
+              uses: pypa/gh-action-pypi-publish@release/v1
+              with:
+                  repository-url: https://test.pypi.org
+
+    publish-to-pypi:
+        name: Publish to PyPI
+        needs: publish-to-testpypi
+        runs-on: ubuntu-latest
+        environment:
+            name: pypi
+            url: https://pypi.org
+        permissions:
+            id-token: write
+        steps:
+            - name: Download all the dists
+              uses: actions/download-artifact@v6
+              with:
+                  name: infer-check
+                  path: dist/
+
+            - name: Publish to TestPyPI
+              uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds an automated release pipeline that publishes artifacts to TestPyPI and then PyPI on `v*` tags, which can impact the package supply chain if misconfigured. Risk is limited to CI/config changes but affects production distribution.
> 
> **Overview**
> Introduces a new GitHub Actions workflow (`.github/workflows/release.yml`) that triggers on `v*` tags to build sdist/wheels with `uv` (Python 3.13), upload them as an artifact, and then **publish sequentially to TestPyPI and PyPI** using OIDC (`pypa/gh-action-pypi-publish`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 26ca62bd9c7d23847ca444ddc342bff6598ceb9a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->