### PR TITLE
Bug/max tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.2.0 (2026-04-02)
+
+- Added global `--max-tokens` flag (defaults to 1024) to the main CLI.
+- Increased default `max_tokens` for all prompts from 256 to 1024.
+
 # 0.1.0 (2026-03-11)
 
 - Initial release

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ pip install "infer-check[mlx]"
 
 ### Quantization sweep
 
-Compare pre-quantized models against a baseline. Each model is a separate HuggingFace repo.
+Compare pre-quantized models against a baseline. Each model is a separate HuggingFace repo. Use `--max-tokens` to control generation length (defaults to 1024).
 
 ```
 infer-check sweep \
@@ -77,6 +77,7 @@ infer-check sweep \
             4bit=mlx-community/Meta-Llama-3.1-8B-Instruct-4bit" \
   --backend mlx-lm \
   --prompts reasoning \
+  --max-tokens 512 \
   --output ./results/sweep/
 ```
 
@@ -161,7 +162,7 @@ Curated prompts targeting known quantization failure modes:
 | `quant-sensitive.jsonl` | 20 | Multi-digit arithmetic, long CoT, precise syntax |
 | `determinism.jsonl` | 50 | High-entropy continuations for determinism testing |
 
-All suites ship with the package — no need to clone the repo. Custom suites are JSONL files with one object per line:
+All suites ship with the package — no need to clone the repo. Custom suites are JSONL files with one object per line (default `max_tokens` is 1024):
 
 ```json
 {"id": "custom-001", "text": "Your prompt here", "category": "math", "max_tokens": 512}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,7 @@ select = ["E", "F", "I", "N", "W", "UP", "B", "SIM"]
 "html.py" = ["E501"]
 
 [tool.mypy]
-python_version = "3.13"
+python_version = "3.11"
 strict = true
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ dev = [
 ]
 
 [tool.ruff]
-target-version = "py313"
+target-version = "py311"
 line-length = 120
 src = ["src"]
 

--- a/src/infer_check/backends/mlx_lm.py
+++ b/src/infer_check/backends/mlx_lm.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import gc
 import time
 from typing import Any, cast
@@ -85,7 +86,7 @@ class MLXBackend:
         """Release model references and trigger garbage collection."""
         self._model = None
         self._tokenizer = None
-        gc.collect()
+        await asyncio.to_thread(gc.collect)
 
     # ------------------------------------------------------------------
     # Internal helpers

--- a/src/infer_check/backends/openai_compat.py
+++ b/src/infer_check/backends/openai_compat.py
@@ -101,6 +101,8 @@ class OpenAICompatBackend:
         choice = data["choices"][0]
         message = choice.get("message", {})
         text: str = message.get("content", "")
+        if not text:
+            text = message.get("reasoning_content", "")
         tokens = text.split()
 
         usage = data.get("usage", {})

--- a/src/infer_check/cli.py
+++ b/src/infer_check/cli.py
@@ -7,7 +7,7 @@ import json
 from collections.abc import Callable
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any, Literal, TypeVar
 
 import click
 from rich.console import Console
@@ -15,8 +15,10 @@ from rich.table import Table
 
 console = Console()
 
+F = TypeVar("F", bound=Callable[..., Any])
 
-def common_options[F: Callable[..., Any]](f: F) -> F:
+
+def common_options(f: F) -> F:
     """Add common options to all subcommands."""
     options = [
         click.option(
@@ -153,7 +155,7 @@ def sweep(
     prompt_list = load_suite(_resolve_prompts(prompts))
     # Apply global max_tokens only if not explicitly set in the prompt JSONL
     for p in prompt_list:
-        if "max_tokens" not in p.metadata.get("__fields_set__", set()):
+        if "max_tokens" not in p.model_fields_set:
             p.max_tokens = ctx.obj["max_tokens"]
 
     # Build a separate backend for each model
@@ -351,7 +353,7 @@ def compare(
     prompt_list = load_suite(_resolve_prompts(prompts))
     # Apply global max_tokens only if not explicitly set in the prompt JSONL
     for p in prompt_list:
-        if "max_tokens" not in p.metadata.get("__fields_set__", set()):
+        if "max_tokens" not in p.model_fields_set:
             p.max_tokens = ctx.obj["max_tokens"]
 
     console.print(f"  prompts: {len(prompt_list)} from '{prompts}'")
@@ -592,7 +594,7 @@ def diff(
     prompt_list = load_suite(_resolve_prompts(prompts))
     # Apply global max_tokens only if not explicitly set in the prompt JSONL
     for p in prompt_list:
-        if "max_tokens" not in p.metadata.get("__fields_set__", set()):
+        if "max_tokens" not in p.model_fields_set:
             p.max_tokens = ctx.obj["max_tokens"]
 
     backend_instances = []
@@ -716,7 +718,7 @@ def stress(
     prompt_list = load_suite(_resolve_prompts(prompts))
     # Apply global max_tokens only if not explicitly set in the prompt JSONL
     for p in prompt_list:
-        if "max_tokens" not in p.metadata.get("__fields_set__", set()):
+        if "max_tokens" not in p.model_fields_set:
             p.max_tokens = ctx.obj["max_tokens"]
 
     runner = TestRunner()
@@ -809,7 +811,7 @@ def determinism(
     prompt_list = load_suite(_resolve_prompts(prompts))
     # Apply global max_tokens only if not explicitly set in the prompt JSONL
     for p in prompt_list:
-        if "max_tokens" not in p.metadata.get("__fields_set__", set()):
+        if "max_tokens" not in p.model_fields_set:
             p.max_tokens = ctx.obj["max_tokens"]
 
     runner = TestRunner()

--- a/src/infer_check/cli.py
+++ b/src/infer_check/cli.py
@@ -129,9 +129,13 @@ def sweep(
         tag = " (baseline)" if label == baseline_label else ""
         console.print(f"  {label}: {path}{tag}")
     prompt_list = load_suite(_resolve_prompts(prompts))
-    # Apply global max_tokens
+    # Apply global max_tokens only when a prompt did not explicitly set its own.
     for p in prompt_list:
-        p.max_tokens = ctx.obj["max_tokens"]
+        fields_set = getattr(p, "model_fields_set", None)
+        if fields_set is None:
+            fields_set = getattr(p, "__pydantic_fields_set__", set())
+        if "max_tokens" not in fields_set:
+            p.max_tokens = ctx.obj["max_tokens"]
 
     # Build a separate backend for each model
     backend_map: dict[str, Any] = {}
@@ -320,9 +324,10 @@ def compare(
     )
 
     prompt_list = load_suite(_resolve_prompts(prompts))
-    # Apply global max_tokens
+    # Apply global max_tokens only when the suite did not set one.
     for p in prompt_list:
-        p.max_tokens = ctx.obj["max_tokens"]
+        if getattr(p, "max_tokens", None) is None:
+            p.max_tokens = ctx.obj["max_tokens"]
 
     console.print(f"  prompts: {len(prompt_list)} from '{prompts}'")
 
@@ -554,9 +559,10 @@ def diff(
     console.print(f"[bold cyan]diff[/bold cyan] model={model} backends={backend_names} quant={quant}")
 
     prompt_list = load_suite(_resolve_prompts(prompts))
-    # Apply global max_tokens
+    # Apply global max_tokens only when the prompt does not already specify one.
     for p in prompt_list:
-        p.max_tokens = ctx.obj["max_tokens"]
+        if getattr(p, "max_tokens", None) is None:
+            p.max_tokens = ctx.obj["max_tokens"]
 
     backend_instances = []
     for name, url in zip(backend_names, url_list, strict=True):
@@ -671,9 +677,10 @@ def stress(
     )
 
     prompt_list = load_suite(_resolve_prompts(prompts))
-    # Apply global max_tokens
+    # Apply global max_tokens only to prompts that do not already specify one.
     for p in prompt_list:
-        p.max_tokens = ctx.obj["max_tokens"]
+        if p.max_tokens is None:
+            p.max_tokens = ctx.obj["max_tokens"]
 
     runner = TestRunner()
     stress_results = asyncio.run(
@@ -757,9 +764,10 @@ def determinism(
     console.print(f"[bold cyan]determinism[/bold cyan] model={model} backend={backend_instance.name} runs={runs}")
 
     prompt_list = load_suite(_resolve_prompts(prompts))
-    # Apply global max_tokens
+    # Apply global max_tokens only when a prompt does not define its own value.
     for p in prompt_list:
-        p.max_tokens = ctx.obj["max_tokens"]
+        if getattr(p, "max_tokens", None) is None:
+            p.max_tokens = ctx.obj["max_tokens"]
 
     runner = TestRunner()
     det_results = asyncio.run(

--- a/src/infer_check/cli.py
+++ b/src/infer_check/cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+from collections.abc import Callable
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, Literal
@@ -13,6 +14,21 @@ from rich.console import Console
 from rich.table import Table
 
 console = Console()
+
+
+def common_options[F: Callable[..., Any]](f: F) -> F:
+    """Add common options to all subcommands."""
+    options = [
+        click.option(
+            "--max-tokens",
+            default=None,
+            type=int,
+            help="Override default max tokens for generation.",
+        ),
+    ]
+    for option in reversed(options):
+        f = option(f)
+    return f
 
 
 def _resolve_prompts(prompts: str) -> Path:
@@ -74,6 +90,7 @@ def main(ctx: click.Context, max_tokens: int) -> None:
     help="Baseline label (defaults to first in --models).",
 )
 @click.option("--base-url", default=None, help="Base URL for HTTP backends.")
+@common_options
 @click.pass_context
 def sweep(
     ctx: click.Context,
@@ -83,6 +100,7 @@ def sweep(
     output: Path,
     baseline: str | None,
     base_url: str | None,
+    max_tokens: int | None,
 ) -> None:
     """Run a quantization sweep: compare pre-quantized models against a baseline.
 
@@ -100,6 +118,10 @@ def sweep(
     from infer_check.backends.base import get_backend_for_model
     from infer_check.runner import TestRunner
     from infer_check.suites.loader import load_suite
+
+    # Update max_tokens from subcommand if provided
+    if max_tokens is not None:
+        ctx.obj["max_tokens"] = max_tokens
 
     # Parse label=model_path pairs
     model_map: dict[str, str] = {}
@@ -129,9 +151,10 @@ def sweep(
         tag = " (baseline)" if label == baseline_label else ""
         console.print(f"  {label}: {path}{tag}")
     prompt_list = load_suite(_resolve_prompts(prompts))
-    # Apply global max_tokens
+    # Apply global max_tokens only if not explicitly set in the prompt JSONL
     for p in prompt_list:
-        p.max_tokens = ctx.obj["max_tokens"]
+        if "max_tokens" not in p.metadata.get("__fields_set__", set()):
+            p.max_tokens = ctx.obj["max_tokens"]
 
     # Build a separate backend for each model
     backend_map: dict[str, Any] = {}
@@ -270,6 +293,7 @@ def sweep(
     show_default=True,
     help="Generate an HTML comparison report after the run.",
 )
+@common_options
 @click.pass_context
 def compare(
     ctx: click.Context,
@@ -281,6 +305,7 @@ def compare(
     label_a: str | None,
     label_b: str | None,
     report: bool,
+    max_tokens: int | None,
 ) -> None:
     """Compare two quantizations of the same model.
 
@@ -310,6 +335,10 @@ def compare(
     from infer_check.runner import TestRunner
     from infer_check.suites.loader import load_suite
 
+    # Update max_tokens from subcommand if provided
+    if max_tokens is not None:
+        ctx.obj["max_tokens"] = max_tokens
+
     resolved_a = resolve_model(model_a, base_url=base_url, label=label_a)
     resolved_b = resolve_model(model_b, base_url=base_url, label=label_b)
 
@@ -320,9 +349,10 @@ def compare(
     )
 
     prompt_list = load_suite(_resolve_prompts(prompts))
-    # Apply global max_tokens
+    # Apply global max_tokens only if not explicitly set in the prompt JSONL
     for p in prompt_list:
-        p.max_tokens = ctx.obj["max_tokens"]
+        if "max_tokens" not in p.metadata.get("__fields_set__", set()):
+            p.max_tokens = ctx.obj["max_tokens"]
 
     console.print(f"  prompts: {len(prompt_list)} from '{prompts}'")
 
@@ -529,6 +559,7 @@ def compare(
     show_default=True,
     help="Use /v1/chat/completions for HTTP backends (applies chat template server-side).",
 )
+@common_options
 @click.pass_context
 def diff(
     ctx: click.Context,
@@ -539,11 +570,16 @@ def diff(
     quant: str | None,
     base_urls: str | None,
     chat: bool,
+    max_tokens: int | None,
 ) -> None:
     """Compare outputs across different backends for the same model and prompts."""
     from infer_check.backends.base import BackendConfig, get_backend
     from infer_check.runner import TestRunner
     from infer_check.suites.loader import load_suite
+
+    # Update max_tokens from subcommand if provided
+    if max_tokens is not None:
+        ctx.obj["max_tokens"] = max_tokens
 
     backend_names = [b.strip() for b in backends.split(",") if b.strip()]
     url_list: list[str | None] = [u.strip() for u in base_urls.split(",")] if base_urls else [None] * len(backend_names)
@@ -554,9 +590,10 @@ def diff(
     console.print(f"[bold cyan]diff[/bold cyan] model={model} backends={backend_names} quant={quant}")
 
     prompt_list = load_suite(_resolve_prompts(prompts))
-    # Apply global max_tokens
+    # Apply global max_tokens only if not explicitly set in the prompt JSONL
     for p in prompt_list:
-        p.max_tokens = ctx.obj["max_tokens"]
+        if "max_tokens" not in p.metadata.get("__fields_set__", set()):
+            p.max_tokens = ctx.obj["max_tokens"]
 
     backend_instances = []
     for name, url in zip(backend_names, url_list, strict=True):
@@ -643,6 +680,7 @@ def diff(
     help="Comma-separated concurrency levels.",
 )
 @click.option("--base-url", default=None, help="Base URL for HTTP backends.")
+@common_options
 @click.pass_context
 def stress(
     ctx: click.Context,
@@ -652,11 +690,16 @@ def stress(
     output: Path,
     concurrency: str,
     base_url: str | None,
+    max_tokens: int | None,
 ) -> None:
     """Stress-test a backend with varying concurrency levels."""
     from infer_check.backends.base import get_backend_for_model
     from infer_check.runner import TestRunner
     from infer_check.suites.loader import load_suite
+
+    # Update max_tokens from subcommand if provided
+    if max_tokens is not None:
+        ctx.obj["max_tokens"] = max_tokens
 
     concurrency_levels = [int(c.strip()) for c in concurrency.split(",") if c.strip()]
 
@@ -671,9 +714,10 @@ def stress(
     )
 
     prompt_list = load_suite(_resolve_prompts(prompts))
-    # Apply global max_tokens
+    # Apply global max_tokens only if not explicitly set in the prompt JSONL
     for p in prompt_list:
-        p.max_tokens = ctx.obj["max_tokens"]
+        if "max_tokens" not in p.metadata.get("__fields_set__", set()):
+            p.max_tokens = ctx.obj["max_tokens"]
 
     runner = TestRunner()
     stress_results = asyncio.run(
@@ -733,6 +777,7 @@ def stress(
 )
 @click.option("--runs", default=100, show_default=True, type=int, help="Number of runs per prompt.")
 @click.option("--base-url", default=None, help="Base URL for HTTP backends.")
+@common_options
 @click.pass_context
 def determinism(
     ctx: click.Context,
@@ -742,11 +787,16 @@ def determinism(
     output: Path,
     runs: int,
     base_url: str | None,
+    max_tokens: int | None,
 ) -> None:
     """Test whether a backend produces identical outputs across repeated runs at temperature=0."""
     from infer_check.backends.base import get_backend_for_model
     from infer_check.runner import TestRunner
     from infer_check.suites.loader import load_suite
+
+    # Update max_tokens from subcommand if provided
+    if max_tokens is not None:
+        ctx.obj["max_tokens"] = max_tokens
 
     backend_instance = get_backend_for_model(
         model_str=model,
@@ -757,9 +807,10 @@ def determinism(
     console.print(f"[bold cyan]determinism[/bold cyan] model={model} backend={backend_instance.name} runs={runs}")
 
     prompt_list = load_suite(_resolve_prompts(prompts))
-    # Apply global max_tokens
+    # Apply global max_tokens only if not explicitly set in the prompt JSONL
     for p in prompt_list:
-        p.max_tokens = ctx.obj["max_tokens"]
+        if "max_tokens" not in p.metadata.get("__fields_set__", set()):
+            p.max_tokens = ctx.obj["max_tokens"]
 
     runner = TestRunner()
     det_results = asyncio.run(

--- a/src/infer_check/cli.py
+++ b/src/infer_check/cli.py
@@ -27,8 +27,17 @@ def _resolve_prompts(prompts: str) -> Path:
 
 @click.group()
 @click.version_option(package_name="infer-check")
-def main() -> None:
+@click.option(
+    "--max-tokens",
+    default=1024,
+    show_default=True,
+    help="Default max tokens for generation (applies to all prompts unless they specify their own).",
+)
+@click.pass_context
+def main(ctx: click.Context, max_tokens: int) -> None:
     """infer-check: correctness and reliability testing for LLM inference engines."""
+    ctx.ensure_object(dict)
+    ctx.obj["max_tokens"] = max_tokens
 
 
 # ---------------------------------------------------------------------------
@@ -65,7 +74,9 @@ def main() -> None:
     help="Baseline label (defaults to first in --models).",
 )
 @click.option("--base-url", default=None, help="Base URL for HTTP backends.")
+@click.pass_context
 def sweep(
+    ctx: click.Context,
     models: str,
     backend: str | None,
     prompts: str,
@@ -117,8 +128,10 @@ def sweep(
     for label, path in model_map.items():
         tag = " (baseline)" if label == baseline_label else ""
         console.print(f"  {label}: {path}{tag}")
-
     prompt_list = load_suite(_resolve_prompts(prompts))
+    # Apply global max_tokens
+    for p in prompt_list:
+        p.max_tokens = ctx.obj["max_tokens"]
 
     # Build a separate backend for each model
     backend_map: dict[str, Any] = {}
@@ -257,7 +270,9 @@ def sweep(
     show_default=True,
     help="Generate an HTML comparison report after the run.",
 )
+@click.pass_context
 def compare(
+    ctx: click.Context,
     model_a: str,
     model_b: str,
     prompts: str,
@@ -305,6 +320,10 @@ def compare(
     )
 
     prompt_list = load_suite(_resolve_prompts(prompts))
+    # Apply global max_tokens
+    for p in prompt_list:
+        p.max_tokens = ctx.obj["max_tokens"]
+
     console.print(f"  prompts: {len(prompt_list)} from '{prompts}'")
 
     # ── Build backends ───────────────────────────────────────────────
@@ -510,7 +529,9 @@ def compare(
     show_default=True,
     help="Use /v1/chat/completions for HTTP backends (applies chat template server-side).",
 )
+@click.pass_context
 def diff(
+    ctx: click.Context,
     model: str,
     backends: str,
     prompts: str,
@@ -533,6 +554,9 @@ def diff(
     console.print(f"[bold cyan]diff[/bold cyan] model={model} backends={backend_names} quant={quant}")
 
     prompt_list = load_suite(_resolve_prompts(prompts))
+    # Apply global max_tokens
+    for p in prompt_list:
+        p.max_tokens = ctx.obj["max_tokens"]
 
     backend_instances = []
     for name, url in zip(backend_names, url_list, strict=True):
@@ -619,7 +643,9 @@ def diff(
     help="Comma-separated concurrency levels.",
 )
 @click.option("--base-url", default=None, help="Base URL for HTTP backends.")
+@click.pass_context
 def stress(
+    ctx: click.Context,
     model: str,
     backend: str | None,
     prompts: str,
@@ -645,6 +671,9 @@ def stress(
     )
 
     prompt_list = load_suite(_resolve_prompts(prompts))
+    # Apply global max_tokens
+    for p in prompt_list:
+        p.max_tokens = ctx.obj["max_tokens"]
 
     runner = TestRunner()
     stress_results = asyncio.run(
@@ -704,7 +733,9 @@ def stress(
 )
 @click.option("--runs", default=100, show_default=True, type=int, help="Number of runs per prompt.")
 @click.option("--base-url", default=None, help="Base URL for HTTP backends.")
+@click.pass_context
 def determinism(
+    ctx: click.Context,
     model: str,
     backend: str | None,
     prompts: str,
@@ -726,6 +757,9 @@ def determinism(
     console.print(f"[bold cyan]determinism[/bold cyan] model={model} backend={backend_instance.name} runs={runs}")
 
     prompt_list = load_suite(_resolve_prompts(prompts))
+    # Apply global max_tokens
+    for p in prompt_list:
+        p.max_tokens = ctx.obj["max_tokens"]
 
     runner = TestRunner()
     det_results = asyncio.run(

--- a/src/infer_check/cli.py
+++ b/src/infer_check/cli.py
@@ -24,7 +24,7 @@ def common_options(f: F) -> F:
         click.option(
             "--max-tokens",
             default=None,
-            type=int,
+            type=click.IntRange(min=1, clamp=True),
             help="Override default max tokens for generation.",
         ),
     ]

--- a/src/infer_check/suites/loader.py
+++ b/src/infer_check/suites/loader.py
@@ -34,8 +34,6 @@ def load_suite(path: str | Path) -> list[Prompt]:
             try:
                 data = json.loads(line)
                 prompt = Prompt.model_validate(data)
-                # Keep track of which fields were explicitly set in the input JSONL
-                prompt.metadata["__fields_set__"] = set(data.keys())
                 prompts.append(prompt)
                 category_counts[prompt.category] += 1
             except json.JSONDecodeError as e:

--- a/src/infer_check/suites/loader.py
+++ b/src/infer_check/suites/loader.py
@@ -34,6 +34,8 @@ def load_suite(path: str | Path) -> list[Prompt]:
             try:
                 data = json.loads(line)
                 prompt = Prompt.model_validate(data)
+                # Keep track of which fields were explicitly set in the input JSONL
+                prompt.metadata["__fields_set__"] = set(data.keys())
                 prompts.append(prompt)
                 category_counts[prompt.category] += 1
             except json.JSONDecodeError as e:

--- a/src/infer_check/types.py
+++ b/src/infer_check/types.py
@@ -48,7 +48,7 @@ class Prompt(BaseInferModel):
     id: str = Field(default_factory=_generate_uuid)
     text: str
     category: str = "general"
-    max_tokens: int = 256
+    max_tokens: int = 1024
     metadata: dict[str, Any] = Field(default_factory=dict)
 
 

--- a/tests/unit/test_cli_max_tokens.py
+++ b/tests/unit/test_cli_max_tokens.py
@@ -1,6 +1,6 @@
 import json
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 from click.testing import CliRunner
 
@@ -16,10 +16,19 @@ def test_max_tokens_prompt_precedence() -> None:
         prompts = [{"text": "Override", "max_tokens": 123}, {"text": "Default"}]
         prompt_path.write_text("\n".join(json.dumps(p) for p in prompts), encoding="utf-8")
 
-        from infer_check.runner import TestRunner
+        from datetime import UTC, datetime
 
-        mock_result = MagicMock()
-        mock_result.__int__.return_value = 0
+        from infer_check.runner import TestRunner
+        from infer_check.types import SweepResult
+
+        mock_result = SweepResult(
+            model_id="m1",
+            backend_name="mlx",
+            quantization_levels=["a", "b"],
+            comparisons=[],
+            timestamp=datetime.now(UTC),
+            summary={},
+        )
 
         with (
             patch("infer_check.cli._resolve_prompts", return_value=prompt_path),
@@ -52,10 +61,19 @@ def test_max_tokens_propagation_override() -> None:
         prompt_path = Path("test_prompts.jsonl")
         prompt_path.write_text(json.dumps({"text": "Hello world"}), encoding="utf-8")
 
-        from infer_check.runner import TestRunner
+        from datetime import UTC, datetime
 
-        mock_result = MagicMock()
-        mock_result.timestamp.return_value = "2023-01-01"
+        from infer_check.runner import TestRunner
+        from infer_check.types import SweepResult
+
+        mock_result = SweepResult(
+            model_id="m1",
+            backend_name="mlx",
+            quantization_levels=["a", "b"],
+            comparisons=[],
+            timestamp=datetime.now(UTC),
+            summary={},
+        )
 
         with (
             patch("infer_check.cli._resolve_prompts", return_value=prompt_path),

--- a/tests/unit/test_cli_max_tokens.py
+++ b/tests/unit/test_cli_max_tokens.py
@@ -1,0 +1,76 @@
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+from infer_check.cli import main
+
+
+def test_max_tokens_prompt_precedence() -> None:
+    """Test that prompt-level max_tokens override takes precedence over global --max-tokens."""
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        prompt_path = Path("test_prompts.jsonl")
+        # One prompt with explicit max_tokens, one without
+        prompts = [{"text": "Override", "max_tokens": 123}, {"text": "Default"}]
+        prompt_path.write_text("\n".join(json.dumps(p) for p in prompts), encoding="utf-8")
+
+        from infer_check.runner import TestRunner
+
+        mock_result = MagicMock()
+        mock_result.__int__.return_value = 0
+
+        with (
+            patch("infer_check.cli._resolve_prompts", return_value=prompt_path),
+            patch("infer_check.backends.base.get_backend_for_model"),
+            patch.object(TestRunner, "sweep", return_value=mock_result) as mock_sweep,
+        ):
+            # Run with global --max-tokens 512
+            result = runner.invoke(
+                main, ["--max-tokens", "512", "sweep", "--models", "a=m1,b=m2", "--prompts", "test_prompts.jsonl"]
+            )
+            assert result.exit_code == 0
+
+            # Check the call to sweep
+            args, kwargs = mock_sweep.call_args
+            captured_prompts = kwargs.get("prompts") or args[2]
+
+            assert len(captured_prompts) == 2
+            # Prompt 1: should keep its own 123
+            assert captured_prompts[0].text == "Override"
+            assert captured_prompts[0].max_tokens == 123
+            # Prompt 2: should get the global 512
+            assert captured_prompts[1].text == "Default"
+            assert captured_prompts[1].max_tokens == 512
+
+
+def test_max_tokens_propagation_override() -> None:
+    """Test that a custom global --max-tokens is propagated."""
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        prompt_path = Path("test_prompts.jsonl")
+        prompt_path.write_text(json.dumps({"text": "Hello world"}), encoding="utf-8")
+
+        from infer_check.runner import TestRunner
+
+        mock_result = MagicMock()
+        mock_result.timestamp.return_value = "2023-01-01"
+
+        with (
+            patch("infer_check.cli._resolve_prompts", return_value=prompt_path),
+            patch("infer_check.backends.base.get_backend_for_model"),
+            patch.object(TestRunner, "sweep", return_value=mock_result) as mock_sweep,
+        ):
+            # Run with --max-tokens 512
+            result = runner.invoke(
+                main, ["--max-tokens", "512", "sweep", "--models", "a=m1,b=m2", "--prompts", "test_prompts.jsonl"]
+            )
+            if result.exception:
+                print(result.exception)
+                raise result.exception
+            assert result.exit_code == 0
+
+            args, kwargs = mock_sweep.call_args
+            captured_prompts = kwargs.get("prompts") or args[2]
+            assert captured_prompts[0].max_tokens == 512

--- a/tests/unit/test_openai_compat.py
+++ b/tests/unit/test_openai_compat.py
@@ -87,3 +87,39 @@ def test_generate_empty_choices() -> None:
         with pytest.raises(RuntimeError) as exc:
             asyncio.run(backend.generate(prompt))
         assert "empty or malformed response" in str(exc.value)
+
+
+def test_generate_chat_reasoning_fallback() -> None:
+    """Test fallback to message.reasoning_content when message.content is missing/empty."""
+    backend = OpenAICompatBackend(base_url="http://127.0.0.1:8000", model_id="dummy", chat=True)
+    prompt = Prompt(id="p1", text="Hello", max_tokens=10)
+
+    # Content empty, reasoning_content present
+    mock_response = httpx.Response(
+        200,
+        json={
+            "choices": [{"message": {"content": "", "reasoning_content": "Thinking... world"}}],
+            "usage": {"completion_tokens": 2},
+        },
+        request=httpx.Request("POST", "http://127.0.0.1:8000/v1/chat/completions"),
+    )
+
+    with patch("httpx.AsyncClient.post", return_value=mock_response):
+        res = asyncio.run(backend.generate(prompt))
+        assert res.text == "Thinking... world"
+        assert res.tokens == ["Thinking...", "world"]
+
+    # Content missing, reasoning_content present
+    mock_response = httpx.Response(
+        200,
+        json={
+            "choices": [{"message": {"reasoning_content": "Just thinking"}}],
+            "usage": {"completion_tokens": 2},
+        },
+        request=httpx.Request("POST", "http://127.0.0.1:8000/v1/chat/completions"),
+    )
+
+    with patch("httpx.AsyncClient.post", return_value=mock_response):
+        res = asyncio.run(backend.generate(prompt))
+        assert res.text == "Just thinking"
+        assert res.tokens == ["Just", "thinking"]


### PR DESCRIPTION
This pull request introduces a new global `--max-tokens` flag to the CLI, increases the default `max_tokens` for all prompts to 1024, and ensures that this value is consistently applied across all commands unless overridden per-prompt. Documentation and help text are updated to reflect these changes, and a minor fix is made for handling alternative response fields in the OpenAI-compatible backend.

**Global max tokens configuration:**

* Added a global `--max-tokens` CLI flag (default: 1024) to set the maximum generation length for all prompts unless individually specified. This value is now passed through the Click context and applied across all main commands (`sweep`, `compare`, `diff`, `stress`, `determinism`). [[1]](diffhunk://#diff-e743b54c41fc5baac39952e179366483ea5951d0d5d13404dbfb331f4b55a935L30-R40) [[2]](diffhunk://#diff-e743b54c41fc5baac39952e179366483ea5951d0d5d13404dbfb331f4b55a935R77-R79) [[3]](diffhunk://#diff-e743b54c41fc5baac39952e179366483ea5951d0d5d13404dbfb331f4b55a935L120-R134) [[4]](diffhunk://#diff-e743b54c41fc5baac39952e179366483ea5951d0d5d13404dbfb331f4b55a935R273-R275) [[5]](diffhunk://#diff-e743b54c41fc5baac39952e179366483ea5951d0d5d13404dbfb331f4b55a935R323-R326) [[6]](diffhunk://#diff-e743b54c41fc5baac39952e179366483ea5951d0d5d13404dbfb331f4b55a935R532-R534) [[7]](diffhunk://#diff-e743b54c41fc5baac39952e179366483ea5951d0d5d13404dbfb331f4b55a935R557-R559) [[8]](diffhunk://#diff-e743b54c41fc5baac39952e179366483ea5951d0d5d13404dbfb331f4b55a935R646-R648) [[9]](diffhunk://#diff-e743b54c41fc5baac39952e179366483ea5951d0d5d13404dbfb331f4b55a935R674-R676) [[10]](diffhunk://#diff-e743b54c41fc5baac39952e179366483ea5951d0d5d13404dbfb331f4b55a935R736-R738) [[11]](diffhunk://#diff-e743b54c41fc5baac39952e179366483ea5951d0d5d13404dbfb331f4b55a935R760-R762)
* Increased the default `max_tokens` for the `Prompt` model from 256 to 1024.

**Documentation updates:**

* Updated `README.md` to document the new `--max-tokens` flag, its default value, and how to use it in example commands and custom prompt suites. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L71-R71) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R80) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L164-R165)
* Added a new release entry in `CHANGELOG.md` describing the global flag and increased default.

**Backend robustness:**

* Improved the OpenAI-compatible backend to fall back to `reasoning_content` if the main `content` field is missing in a chat completion response.